### PR TITLE
Add OpenAI-based C# test generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Build artifacts
+bin/
+obj/
+# User-specific files
+*.user
+*.suo

--- a/AutomatedTesting.sln
+++ b/AutomatedTesting.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenAITestGenerator", "OpenAITestGenerator\OpenAITestGenerator.csproj", "{536628C8-44A9-4D0B-9326-A8C79550A458}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{536628C8-44A9-4D0B-9326-A8C79550A458}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{536628C8-44A9-4D0B-9326-A8C79550A458}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{536628C8-44A9-4D0B-9326-A8C79550A458}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{536628C8-44A9-4D0B-9326-A8C79550A458}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/OpenAITestGenerator/OpenAITestGenerator.csproj
+++ b/OpenAITestGenerator/OpenAITestGenerator.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenAI" Version="1.8.0" />
+  </ItemGroup>
+
+</Project>

--- a/OpenAITestGenerator/Program.cs
+++ b/OpenAITestGenerator/Program.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using OpenAI_API;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        string apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            Console.Error.WriteLine("Please set the OPENAI_API_KEY environment variable.");
+            return;
+        }
+
+        Console.WriteLine("Describe the UI or API tests you want to generate:");
+        string prompt = Console.ReadLine();
+        if (string.IsNullOrWhiteSpace(prompt))
+        {
+            Console.Error.WriteLine("No prompt provided.");
+            return;
+        }
+
+        var api = new OpenAIAPI(apiKey);
+        var completionRequest = new OpenAI_API.Completions.CompletionRequest()
+        {
+            Prompt = $"Generate C# automated tests for the following scenario:\n{prompt}",
+            Model = OpenAI_API.Models.Model.DavinciText,
+            MaxTokens = 400
+        };
+
+        Console.WriteLine("Generating test script with OpenAI...");
+        var result = await api.Completions.CreateCompletionAsync(completionRequest);
+        string text = result.ToString();
+        Console.WriteLine("--- Generated Test Script ---\n");
+        Console.WriteLine(text);
+        File.WriteAllText("GeneratedTest.cs", text);
+        Console.WriteLine("Saved to GeneratedTest.cs");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# AgenticAi
+# AgenticAI
+
+This repository contains a simple C# project that demonstrates how to generate automated UI and API test scripts using OpenAI's language model.
+
+## Projects
+
+- **AutomatedTesting.sln** – Solution file containing the `OpenAITestGenerator` console application.
+- **OpenAITestGenerator** – Console application that calls the OpenAI API to generate C# test code.
+
+## Usage
+
+1. Install the .NET 8 SDK and ensure `dotnet` is available.
+2. Set the environment variable `OPENAI_API_KEY` with your OpenAI API key.
+3. Build and run the console application:
+
+   ```bash
+   dotnet run --project OpenAITestGenerator
+   ```
+
+4. When prompted, enter a description of the UI or API scenario you want tests for. The generated C# test script will be displayed and saved to `GeneratedTest.cs`.


### PR DESCRIPTION
## Summary
- create new solution with `OpenAITestGenerator` console app
- call the OpenAI API to generate C# test scripts from a prompt
- ignore build artifacts in `.gitignore`
- document usage in README

## Testing
- `dotnet build AutomatedTesting.sln`

------
https://chatgpt.com/codex/tasks/task_e_684833eb5f48832fa808ff2988e454f0