### PR TITLE
Add Selenium WebTestExecutor

### DIFF
--- a/AutomatedTesting.sln
+++ b/AutomatedTesting.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenAITestGenerator", "Open
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeneratedTests", "GeneratedTests\GeneratedTests.csproj", "{C185AFE7-2142-47E2-AF74-B6048AFC927D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebTestExecutor", "WebTestExecutor\WebTestExecutor.csproj", "{0D933656-25C3-4B3F-9065-54DCC1C2A245}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
                 {C185AFE7-2142-47E2-AF74-B6048AFC927D}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {C185AFE7-2142-47E2-AF74-B6048AFC927D}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {C185AFE7-2142-47E2-AF74-B6048AFC927D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {0D933656-25C3-4B3F-9065-54DCC1C2A245}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0D933656-25C3-4B3F-9065-54DCC1C2A245}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0D933656-25C3-4B3F-9065-54DCC1C2A245}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0D933656-25C3-4B3F-9065-54DCC1C2A245}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains a simple C# project that demonstrates how to generate a
 - **AutomatedTesting.sln** – Solution file containing the `OpenAITestGenerator` console application.
 - **OpenAITestGenerator** – Console application that calls the OpenAI API to generate C# test code.
 - **GeneratedTests** – xUnit test project where OpenAI generates test files.
+- **WebTestExecutor** – Console application that executes AI-generated web test steps using Selenium WebDriver.
 
 ## Usage
 
@@ -18,3 +19,8 @@ This repository contains a simple C# project that demonstrates how to generate a
    dotnet run --project OpenAITestGenerator
    ```
 4. When the program starts you will be asked to either upload a user story or select an existing one from the `UserStories` folder. Selecting a story will trigger test generation and attempt to run the generated tests inside the `GeneratedTests` project. The application will create the `UserStories` folder automatically if it does not exist.
+5. To execute web scenarios, build and run the WebTestExecutor project with a scenario description as argument:
+
+   ```bash
+   dotnet run --project WebTestExecutor "Login scenario"
+   ```

--- a/WebTestExecutor/Program.cs
+++ b/WebTestExecutor/Program.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenAI_API;
+using OpenAI_API.Completions;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+namespace WebTestExecutor
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Usage: WebTestExecutor <scenario>");
+                return;
+            }
+
+            string scenario = string.Join(" ", args);
+            string apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                Console.Error.WriteLine("OPENAI_API_KEY environment variable is not set.");
+                return;
+            }
+
+            var api = new OpenAIAPI(apiKey);
+            var request = new CompletionRequest
+            {
+                Prompt = $"Generate step by step instructions to test the following scenario using a web browser:\n{scenario}\nProvide one instruction per line.",
+                Model = OpenAI_API.Models.Model.DavinciText,
+                MaxTokens = 150
+            };
+
+            Console.WriteLine("Generating test steps with OpenAI...");
+            var result = await api.Completions.CreateCompletionAsync(request);
+            string stepsText = result.ToString();
+            var steps = stepsText.Split(new[] {'\n'}, StringSplitOptions.RemoveEmptyEntries)
+                                  .Select(s => s.TrimStart('-',' ')).ToArray();
+
+            Console.WriteLine("Executing steps...");
+            using var driver = new ChromeDriver();
+            Directory.CreateDirectory("Screenshots");
+
+            for (int i = 0; i < steps.Length; i++)
+            {
+                string step = steps[i];
+                Console.WriteLine($"Step {i + 1}: {step}");
+                ExecuteStep(driver, step);
+                CaptureScreenshot(driver, i + 1);
+            }
+
+            Console.WriteLine("Test execution complete.");
+            driver.Quit();
+        }
+
+        static void ExecuteStep(IWebDriver driver, string step)
+        {
+            var parts = step.Split(' ');
+            if (parts.Length == 0) return;
+
+            switch (parts[0].ToLower())
+            {
+                case "open":
+                    if (parts.Length > 1)
+                        driver.Navigate().GoToUrl(parts[1]);
+                    break;
+                case "click":
+                    if (parts.Length > 1)
+                        driver.FindElement(By.CssSelector(parts[1])).Click();
+                    break;
+                case "type":
+                    if (parts.Length > 2)
+                        driver.FindElement(By.CssSelector(parts[2])).SendKeys(parts[1]);
+                    break;
+                case "wait":
+                    if (parts.Length > 1 && int.TryParse(parts[1], out int ms))
+                        Thread.Sleep(ms);
+                    break;
+                default:
+                    Console.WriteLine($"Unknown action: {parts[0]}");
+                    break;
+            }
+        }
+
+        static void CaptureScreenshot(IWebDriver driver, int index)
+        {
+            try
+            {
+                var screenshot = ((ITakesScreenshot)driver).GetScreenshot();
+                string file = Path.Combine("Screenshots", $"step{index:00}.png");
+                screenshot.SaveAsFile(file, ScreenshotImageFormat.Png);
+                Console.WriteLine($"Saved screenshot: {file}");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Screenshot failed: {ex.Message}");
+            }
+        }
+    }
+}

--- a/WebTestExecutor/WebTestExecutor.csproj
+++ b/WebTestExecutor/WebTestExecutor.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Selenium.WebDriver" Version="4.33.0" />
+    <PackageReference Include="Selenium.Support" Version="4.33.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="137.0.7151.6800" />
+    <PackageReference Include="OpenAI" Version="1.6.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add `WebTestExecutor` project for Selenium-based execution of OpenAI test steps
- record project in the solution and README

## Testing
- `dotnet test GeneratedTests/GeneratedTests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483ce61c58832f9aa2d221de6749cc